### PR TITLE
Underscore metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ should now look like:
 - [#1374](https://github.com/influxdata/telegraf/pull/1374): Change "default" retention policy to "".
 - [#1377](https://github.com/influxdata/telegraf/issues/1377): Graphite output mangling '%' character.
 - [#1396](https://github.com/influxdata/telegraf/pull/1396): Prometheus input plugin now supports x509 certs authentication
+- [#1](https://github.com/Instrumental/telegraf/pull/1): Instrumental output has better reconnect behavior
 
 ## v1.0 beta 1 [2016-06-07]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ should now look like:
 - [#1405](https://github.com/influxdata/telegraf/issues/1405): Fix memory/connection leak in prometheus input plugin.
 - [#1378](https://github.com/influxdata/telegraf/issues/1378): Trim BOM from config file for Windows support.
 - [#1339](https://github.com/influxdata/telegraf/issues/1339): Prometheus client output panic on service reload.
+- [#1412](https://github.com/influxdata/telegraf/pull/1412): Instrumental output has better reconnect behavior
 
 ## v1.0 beta 2 [2016-06-21]
 
@@ -61,7 +62,6 @@ should now look like:
 - [#1374](https://github.com/influxdata/telegraf/pull/1374): Change "default" retention policy to "".
 - [#1377](https://github.com/influxdata/telegraf/issues/1377): Graphite output mangling '%' character.
 - [#1396](https://github.com/influxdata/telegraf/pull/1396): Prometheus input plugin now supports x509 certs authentication
-- [#1](https://github.com/Instrumental/telegraf/pull/1): Instrumental output has better reconnect behavior
 
 ## v1.0 beta 1 [2016-06-07]
 

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -28,9 +28,9 @@ type Instrumental struct {
 }
 
 const (
-	DefaultHost     = "collector.instrumentalapp.com"
-	HelloMessage    = "hello version go/telegraf/1.1\n"
-	AuthFormat      = "authenticate %s\n"
+	DefaultHost  = "collector.instrumentalapp.com"
+	HelloMessage = "hello version go/telegraf/1.1\n"
+	AuthFormat   = "authenticate %s\n"
 )
 
 var (

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -29,7 +29,7 @@ type Instrumental struct {
 
 const (
 	DefaultHost     = "collector.instrumentalapp.com"
-	HelloMessage    = "hello version go/telegraf/1.0\n"
+	HelloMessage    = "hello version go/telegraf/1.1\n"
 	AuthFormat      = "authenticate %s\n"
 )
 

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	ValueIncludesBadChar = regexp.MustCompile("[^[:digit:].]")
-	MetricNameReplacer = regexp.MustCompile("[^-[:alnum:]_.]")
+	MetricNameReplacer = regexp.MustCompile("[^-[:alnum:]_.]+")
 )
 
 var sampleConfig = `

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -34,7 +34,8 @@ const (
 )
 
 var (
-	StatIncludesBadChar = regexp.MustCompile("[^[:alnum:][:blank:]-_.]")
+	ValueIncludesBadChar = regexp.MustCompile("[^[:digit:].]")
+	MetricNameReplacer = regexp.MustCompile("[^-[:alnum:]_.]")
 )
 
 var sampleConfig = `
@@ -136,8 +137,17 @@ func (i *Instrumental) Write(metrics []telegraf.Metric) error {
 		}
 
 		for _, stat := range stats {
-			if !StatIncludesBadChar.MatchString(stat) {
-				points = append(points, fmt.Sprintf("%s %s", metricType, stat))
+			// decompose "metric.name value time"
+			splitStat := strings.SplitN(stat, " ", 3)
+			metric := splitStat[0]
+			value := splitStat[1]
+			time := splitStat[2]
+
+			// replace invalid components of metric name with underscore
+			clean_metric := MetricNameReplacer.ReplaceAllString(metric, "_")
+
+			if !ValueIncludesBadChar.MatchString(value) {
+				points = append(points, fmt.Sprintf("%s %s %s %s", metricType, clean_metric, value, time))
 			} else if i.Debug {
 				log.Printf("Unable to send bad stat: %s", stat)
 			}

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -24,7 +24,6 @@ func TestWrite(t *testing.T) {
 		ApiToken: "abc123token",
 		Prefix:   "my.prefix",
 	}
-	i.Connect()
 
 	// Default to gauge
 	m1, _ := telegraf.NewMetric(
@@ -40,10 +39,8 @@ func TestWrite(t *testing.T) {
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 
-	// Simulate a connection close and reconnect.
 	metrics := []telegraf.Metric{m1, m2}
 	i.Write(metrics)
-	i.Close()
 
 	// Counter and Histogram are increments
 	m3, _ := telegraf.NewMetric(
@@ -70,7 +67,6 @@ func TestWrite(t *testing.T) {
 	i.Write(metrics)
 
 	wg.Wait()
-	i.Close()
 }
 
 func TCPServer(t *testing.T, wg *sync.WaitGroup) {
@@ -82,11 +78,11 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 	tp := textproto.NewReader(reader)
 
 	hello, _ := tp.ReadLine()
-	assert.Equal(t, "hello version go/telegraf/1.0", hello)
+	assert.Equal(t, "hello version go/telegraf/1.1", hello)
+	conn.Write([]byte("ok\n"))
 	auth, _ := tp.ReadLine()
 	assert.Equal(t, "authenticate abc123token", auth)
-
-	conn.Write([]byte("ok\nok\n"))
+	conn.Write([]byte("ok\n"))
 
 	data1, _ := tp.ReadLine()
 	assert.Equal(t, "gauge my.prefix.192_168_0_1.mymeasurement.myfield 3.14 1289430000", data1)
@@ -99,11 +95,12 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 	tp = textproto.NewReader(reader)
 
 	hello, _ = tp.ReadLine()
-	assert.Equal(t, "hello version go/telegraf/1.0", hello)
+	assert.Equal(t, "hello version go/telegraf/1.1", hello)
+	conn.Write([]byte("ok\n"))
+
 	auth, _ = tp.ReadLine()
 	assert.Equal(t, "authenticate abc123token", auth)
-
-	conn.Write([]byte("ok\nok\n"))
+	conn.Write([]byte("ok\n"))
 
 	data3, _ := tp.ReadLine()
 	assert.Equal(t, "increment my.prefix.192_168_0_1.my_histogram 3.14 1289430000", data3)

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -49,7 +49,7 @@ func TestWrite(t *testing.T) {
 		map[string]interface{}{"value": float64(3.14)},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	// We will drop metric names that won't be accepted by Instrumental
+	// We will modify metric names that won't be accepted by Instrumental
 	m4, _ := telegraf.NewMetric(
 		"bad_metric_name",
 		map[string]string{"host": "192.168.0.1:8888::123", "metric_type": "counter"},

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -52,7 +52,7 @@ func TestWrite(t *testing.T) {
 	// We will drop metric names that won't be accepted by Instrumental
 	m4, _ := telegraf.NewMetric(
 		"bad_metric_name",
-		map[string]string{"host": "192.168.0.1:8888", "metric_type": "counter"},
+		map[string]string{"host": "192.168.0.1:8888::123", "metric_type": "counter"},
 		map[string]interface{}{"value": 1},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
@@ -113,7 +113,7 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 	assert.Equal(t, "increment my.prefix.192_168_0_1.my_histogram 3.14 1289430000", data3)
 
 	data4, _ := tp.ReadLine()
-	assert.Equal(t, "increment my.prefix.192_168_0_1_8888.bad_metric_name 1 1289430000", data4)
+	assert.Equal(t, "increment my.prefix.192_168_0_1_8888_123.bad_metric_name 1 1289430000", data4)
 
 	data5, _ := tp.ReadLine()
 	assert.Equal(t, "increment my.prefix.192_168_0_1.my_counter 3.14 1289430000", data5)

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -49,21 +49,28 @@ func TestWrite(t *testing.T) {
 		map[string]interface{}{"value": float64(3.14)},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	// We will drop metrics that simply won't be accepted by Instrumental
+	// We will drop metric names that won't be accepted by Instrumental
 	m4, _ := telegraf.NewMetric(
+		"bad_metric_name",
+		map[string]string{"host": "192.168.0.1:8888", "metric_type": "counter"},
+		map[string]interface{}{"value": "\" 1\""},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+	// We will drop metric values that won't be accepted by Instrumental
+	m5, _ := telegraf.NewMetric(
 		"bad_values",
 		map[string]string{"host": "192.168.0.1", "metric_type": "counter"},
 		map[string]interface{}{"value": "\" 3:30\""},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	m5, _ := telegraf.NewMetric(
+	m6, _ := telegraf.NewMetric(
 		"my_counter",
 		map[string]string{"host": "192.168.0.1", "metric_type": "counter"},
 		map[string]interface{}{"value": float64(3.14)},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 
-	metrics = []telegraf.Metric{m3, m4, m5}
+	metrics = []telegraf.Metric{m3, m4, m5, m6}
 	i.Write(metrics)
 
 	wg.Wait()

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -53,7 +53,7 @@ func TestWrite(t *testing.T) {
 	m4, _ := telegraf.NewMetric(
 		"bad_metric_name",
 		map[string]string{"host": "192.168.0.1:8888", "metric_type": "counter"},
-		map[string]interface{}{"value": "\" 1\""},
+		map[string]interface{}{"value": 1},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 	// We will drop metric values that won't be accepted by Instrumental
@@ -111,11 +111,15 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 
 	data3, _ := tp.ReadLine()
 	assert.Equal(t, "increment my.prefix.192_168_0_1.my_histogram 3.14 1289430000", data3)
+
 	data4, _ := tp.ReadLine()
-	assert.Equal(t, "increment my.prefix.192_168_0_1.my_counter 3.14 1289430000", data4)
+	assert.Equal(t, "increment my.prefix.192_168_0_1_8888.bad_metric_name 1 1289430000", data4)
 
 	data5, _ := tp.ReadLine()
-	assert.Equal(t, "", data5)
+	assert.Equal(t, "increment my.prefix.192_168_0_1.my_counter 3.14 1289430000", data5)
+
+	data6, _ := tp.ReadLine()
+	assert.Equal(t, "", data6)
 
 	conn.Close()
 }

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -114,5 +114,8 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 	data4, _ := tp.ReadLine()
 	assert.Equal(t, "increment my.prefix.192_168_0_1.my_counter 3.14 1289430000", data4)
 
+	data5, _ := tp.ReadLine()
+	assert.Equal(t, "", data5)
+
 	conn.Close()
 }


### PR DESCRIPTION
**WARNING:** This branch includes #1. 

This replaces all invalid characters in metric names with underscores. Fixing issues where `host:port.metric` would be marked as invalid and not sent.
